### PR TITLE
Catch exceptions during image request

### DIFF
--- a/src/plugins/nsfw_image_detector.py
+++ b/src/plugins/nsfw_image_detector.py
@@ -150,8 +150,11 @@ class NSFWImageDetectorPlugin(BotPlugin):
         Download image in a temporary directory and return path to the
         downloaded file.
         """
-        extension = os.path.splitext(url)[1]
-        response = requests.get(url, stream=True)
+        try:
+          extension = os.path.splitext(url)[1]
+          response = requests.get(url, stream=True)
+        except:
+          return
 
         if not response.status_code == 200:
             return


### PR DESCRIPTION
GRRM kills bots, too...
https://d24w6bsrhbeh9d.cloudfront.net/photo/aVO6xnK_700b_v2.jpg

```
error: uncaptured python exception, closing channel <handler.Bot connected irc.freenode.org:6667 at 0x7f8b7e1c74d0> (<class 'requests.exceptions.SSLError'>:[Errno 1]
_ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure [/usr/lib/python2.7/asyncore.py|read|83]
[/usr/lib/python2.7/asyncore.py|handle_read_event|449]
[/usr/lib/python2.7/asynchat.py|handle_read|158]
[/home/hairy/dev/botko/src/handler.py|found_terminator|64]
[/home/hairy/dev/botko/src/logic.py|new_input|104]
[/home/hairy/dev/botko/src/plugins/nsfw_image_detector.py|handle_message|59]
[/home/hairy/dev/botko/src/plugins/nsfw_image_detector.py|_process_images|74]
[/home/hairy/dev/botko/src/plugins/nsfw_image_detector.py|_download_image|154]
[/usr/local/lib/python2.7/dist-packages/requests/api.py|get|55]
[/usr/local/lib/python2.7/dist-packages/requests/api.py|request|44]
[/usr/local/lib/python2.7/dist-packages/requests/sessions.py|request|361]
[/usr/local/lib/python2.7/dist-packages/requests/sessions.py|send|464]
[/usr/local/lib/python2.7/dist-packages/requests/adapters.py|send|363])
```
